### PR TITLE
[WIP] Added support for Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,148 @@
+# Control file for Appveyor CI (https://www.appveyor.com/)
+# Must be located in the root directory of the Git repository.
+
+environment:
+  matrix:
+    - PYTHON_VERSION: 2.7
+      PYTHON_ARCH: 32
+      PYTHON_HOME: C:/Python27
+#      SQL: MySQL57
+#    - PYTHON_VERSION: 2.7
+#      PYTHON_ARCH: 64
+#      PYTHON_HOME: C:\Python27-x64
+#    - PYTHON_VERSION: 3.4
+#      PYTHON_ARCH: 32
+#      PYTHON_HOME: C:\Python34
+#    - PYTHON_VERSION: 3.4
+#      PYTHON_ARCH: 64
+#      PYTHON_HOME: C:\Python34-x64
+#    - PYTHON_VERSION: 3.5
+#      PYTHON_ARCH: 32
+#      PYTHON_HOME: C:\Python35
+#    - PYTHON_VERSION: 3.5
+#      PYTHON_ARCH: 64
+#      PYTHON_HOME: C:\Python35-x64
+#    - PYTHON_VERSION: 3.6
+#      PYTHON_ARCH: 32
+#      PYTHON_HOME: C:\Python36
+#    - PYTHON_VERSION: 3.6
+#      PYTHON_ARCH: 64
+#      PYTHON_HOME: C:\Python36-x64
+
+configuration:
+# These values will become the values of the PACKAGE_LEVEL env.var.
+#  - minimum
+  - latest
+
+install:
+
+  - if %APPVEYOR_REPO_BRANCH%.==manual-ci-run. set _NEED_REBASE=true
+  - if %_NEED_REBASE%.==true. git fetch origin master
+  - if %_NEED_REBASE%.==true. git branch master FETCH_HEAD
+  - if %_NEED_REBASE%.==true. git rebase master
+  - git branch -av
+
+  # TODO: Use the _MANUAL_CI_RUN variable in tox.ini to run certain parts only when set
+  - if %APPVEYOR_REPO_BRANCH%.==manual-ci-run. set _MANUAL_CI_RUN=true
+  - if %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%.==manual-ci-run. set _MANUAL_CI_RUN=true
+
+  # Set PACKAGE_LEVEL for make
+  - set PACKAGE_LEVEL=%configuration%
+
+  # Examine the environment
+  - set
+  - dir C:\
+  - dir "C:\Program Files"
+  - dir "C:\Program Files (x86)"
+  - dir
+
+  # Show OS-level packages available for installation via "choco"
+  # Note: "choco" is a Windows installer, similar to "yum" on RHEL.
+  # - choco source list
+
+  # Add Python
+  #- reg ADD HKCU\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
+  #- reg ADD HKLM\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%\Scripts;%PATH%
+
+  ## Install pip via get-pip.py - disabled because pip is already installed
+  #- ps: (new-object System.Net.WebClient).Downloadfile('https://bootstrap.pypa.io/get-pip.py', 'C:\Users\appveyor\get-pip.py')
+  #- ps: Start-Process -FilePath "C:\Python27\python.exe" -ArgumentList "C:\Users\appveyor\get-pip.py" -Wait -Passthru
+
+  # Add CygWin
+  - set PATH=C:\cygwin\bin;%PATH%
+
+  # CygWin also has a Python - we don't want to use it.
+  - set PYTHON_CMD=%PYTHON_HOME%/python.exe
+  - set PIP_CMD=%PYTHON_HOME%/Scripts/pip
+
+  # Install MySQL Connector C (it provides header files for the MySQL-python / mysqlclient packages).
+  - set MYSQL_CON^NECTOR_NAME=mysql-connector-c-6.1.10-winx64
+  # - set MYSQL_CONNECTOR_NAME=mysql-connector-c-noinstall-6.0.2-winx64-vs2005
+  - set MYSQL_CONNECTOR_FILE=%MYSQL_CONNECTOR_NAME%.zip
+  - set MYSQL_CONNECTOR_URL=https://dev.mysql.com/get/Downloads/Connector-C/%MYSQL_CONNECTOR_FILE%
+  - set MYSQL_CONNECTOR_DIR=%CD%\%MYSQL_CONNECTOR_NAME%
+  - curl --insecure --location --output %MYSQL_CONNECTOR_FILE% %MYSQL_CONNECTOR_URL% 
+  - 7z x %MYSQL_CONNECTOR_FILE%
+  - find %MYSQL_CONNECTOR_DIR% -name "*.lib"
+  - find %MYSQL_CONNECTOR_DIR% -name "*.h"
+  - md "C:\Program Files (x86)\MySQL\MySQL Connector C 6.1"
+  - mklink /D "C:\Program Files (x86)\MySQL\MySQL Connector C 6.1\include" %MYSQL_CONNECTOR_DIR%\include
+  - mklink /D "C:\Program Files (x86)\MySQL\MySQL Connector C 6.1\lib" %MYSQL_CONNECTOR_DIR%\lib
+  # - mklink /D "C:\Program Files (x86)\MySQL\MySQL Connector C 6.1\lib\vs9" %MYSQL_CONNECTOR_DIR%\lib\vs12
+
+  ## Example for installing an OS-level package via "choco":
+  #
+  #- choco install -y <package-name>
+  #- set PATH=<package-path>;%PATH%
+
+  ## Example for manually installing OS-level prereqs:
+  #
+  ## Preparation
+  #- echo set _PWD=%%%%~dp0>tmp_prereq_dir.bat
+  #- call tmp_prereq_dir.bat
+  #- rm tmp_prereq_dir.bat
+  #- set _PREREQ_DIR=prereqs
+  #- set _PREREQ_ABSDIR=%_PWD%%_PREREQ_DIR%
+  #- echo Installing OS-level prereqs into: %_PREREQ_ABSDIR%
+  #- mkdir %_PREREQ_DIR%
+  #
+  ## Install libxml2
+  #- set _PKGFILE=libxml2-2.7.8.win32.zip
+  #- set _PKGDIR=libxml2-2.7.8.win32
+  #- wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
+  #- unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
+  #- set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
+  #- set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
+  #- set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+
+  # Verify that the commands used in tox.ini are available
+  - make --version
+  - sh --version
+
+  # Verify that the commands used in Makefile are available
+  - bash --version
+  - rm --version
+  - mv --version
+  - find --version
+  - tee --version
+  - call %PIP_CMD% --version
+  - call %PYTHON_CMD% --version
+
+# This is not a C# project, build stuff at the test step instead:
+build: false
+
+before_test:
+  - virtualenv venv -p %PYTHON_CMD%
+  - call venv/Scripts/activate.bat
+  - call %PYTHON_CMD% -c "import setuptools as m; print(m.__file__)"
+  - call %PIP_CMD% --version
+  - call %PYTHON_CMD% --version
+
+test_script:
+  - call %PIP_CMD% list
+  - make install
+  - make develop
+  - call %PIP_CMD% list
+  - make test
+


### PR DESCRIPTION
WIP.

The current issue is that I did not find a package yet that has the right version of `mysqlclient.lib` in it. See this StackOverflow question withz details about the issues: https://stackoverflow.com/q/47044149/1424462

Because of this, Appveyor had been reduced to build just this branch (`andy/add-appveyor-ci`) for now. Once the issue is resolved, change that back to building for all branches.